### PR TITLE
Provide a homepage link for rubygems.org now that the gem is public

### DIFF
--- a/google_cells.gemspec
+++ b/google_cells.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |spec|
   spec.email         = ["jmthrower@gmail.com"]
   spec.summary       = %q{Google Spreadsheets API wrapper}
   spec.description   = %q{An intuitive Google Spreadsheets API wrapper}
-  spec.homepage      = ""
+  spec.homepage      = "https://github.com/jmthrower/google-cells"
   spec.license       = "MIT"
 
   spec.files         = `git ls-files -z`.split("\x0")


### PR DESCRIPTION
There should be homepage info so when you find the gem at http://rubygems.org/gems/google-cells you have a link to the README etc.
