### PR TITLE
Parse time when creating revision from API response

### DIFF
--- a/lib/google_cells/revision.rb
+++ b/lib/google_cells/revision.rb
@@ -29,7 +29,7 @@ module GoogleCells
     def self.parse_from_entry(entry)
       author = entry['lastModifyingUser']
       { id: entry['id'],
-        updated_at: entry['modifiedDate'],
+        updated_at: Time.parse(entry['modifiedDate']),
         etag: entry['etag'],
         author: (author.nil? ? nil : Author.new(
           name: author['displayName'],

--- a/spec/google_cells/revision_spec.rb
+++ b/spec/google_cells/revision_spec.rb
@@ -26,7 +26,7 @@ describe GoogleCells::Revision do
       r = revisions.last
       r.id.should eq "22"
       r.etag.should be
-      r.updated_at.should be
+      r.updated_at.should be_a Time
       r.spreadsheet_key.should be
     end
 


### PR DESCRIPTION
While I expect that having a string here is probably fine for most purposes, when re-creating a function to extract the latest revision from a spreadsheet's revisions collection, I was parsing the created_at field myself so I could compare actual Time objects instead of mere Strings. Thought it might be worth having the timestamp field on the model always return a Time object, as I was initially expecting this to be its type.
